### PR TITLE
Used array.reduce to generate enum objects in a efficient way

### DIFF
--- a/pause-recording-plugin/src/enums/index.js
+++ b/pause-recording-plugin/src/enums/index.js
@@ -1,20 +1,13 @@
-export const ParticipantStatus = {
-  joined: 'joined',
-  left: 'left'
-};
+function makeEnumObject(obj, key) {
+  if(!obj instanceof Object)
+    throw new Error("Passed object is not an object");
+  
+  obj[key] = key;
+  return obj;
+}
 
-export const ParticipantType = {
-  customer: 'customer',
-  unknown: 'unknown',
-  worker: 'worker'
-};
+export const ParticipantStatus = ['joined', 'left'].reduce(makeEnumObject, {});
 
-export const ReservationEvents = {
-  accepted: 'accepted',
-  rejected: 'rejected',
-  timeout: 'timeout',
-  canceled: 'canceled',
-  rescinded: 'rescinded',
-  completed: 'completed',
-  wrapup: 'wrapup'
-};
+export const ParticipantType = ['customer', 'unknown', 'worker'].reduce(makeEnumObject, {});
+
+export const ReservationEvents = ['accepted', 'rejected', 'timeout', 'canceled', 'rescinded', 'completed', 'wrapup'].reduce(makeEnumObject, {});


### PR DESCRIPTION
Instead of generating enum objects as the following:-
```js
const enumObject = {
    key1: key1,
    key2: key2
};
```
we can do the following:-
```js
const enumObject = ['key1', 'key2'].reduce((acc, curr) => {
    acc[curr] = curr;
    return acc;
}, {});
```